### PR TITLE
formatting tweak

### DIFF
--- a/_posts/2017-02-09-S×3-final-touches.md
+++ b/_posts/2017-02-09-S×3-final-touches.md
@@ -15,16 +15,16 @@ featuredimg: polar-bear.jpg #if you put an image here it goes on twitter too
 author: aiden
 ---
 
-#S×3 Final Touches
 The S×3 is very close to being ready to plug in to the Raspberry Pis and collecting data!
 
-##Current state
+## Current state
 - All have been bootloaded and are programmable via USB on my windows 10 machine.
 - A python script has been written to accept data over USB and print to file via stdout.
 - Alex has assisted in setting up scripts (python and shell) and my own AWS server to collect the sensor data from the RPis
 
-##What's left?
+## What's left?
 _Calibration of the analogue sensors is needed_
+
 - Temperature
     + currently the function ([Steinhart-Hart Equation](https://en.wikipedia.org/wiki/Steinhart%E2%80%93Hart_equation)) which transforms the ADC thermistor resitances to temperature is giving ~37°C. I have a feeling this is incorrect...
     + This **slight** discrepancy is possibly due to incorrect coefficients being used in the equation, I assumed the values from the [Vishay datasheet](http://www.vishay.com/docs/29049/ntcle100.pdf) would give the correct temperature.


### PR DESCRIPTION
the version of markdown that GH pages runs needs a space after the hash for headings

#not a heading

# actually a heading